### PR TITLE
Add DBus permission to org.freedesktop.secrets

### DIFF
--- a/org.kde.kasts.json
+++ b/org.kde.kasts.json
@@ -12,7 +12,8 @@
         "--socket=wayland",
         "--device=dri",
         "--socket=pulseaudio",
-        "--own-name=org.mpris.MediaPlayer2.kasts"
+        "--own-name=org.mpris.MediaPlayer2.kasts",
+        "--talk-name=org.freedesktop.secrets"
     ],
     "modules": [
         {


### PR DESCRIPTION
Without this permission, qtkeychain cannot connect to the secret
service.  Hence no passwords can be stored/retrieved, which means that
Kasts is not able to sync with gpodder or gpodder-nextcloud without a
full reset of the sync properties.