### PR TITLE
Work around problems with libsecret > 0.20 in flatpak

### DIFF
--- a/org.kde.kasts.json
+++ b/org.kde.kasts.json
@@ -43,7 +43,8 @@
                 "-Dmanpage=false",
                 "-Dvapi=false",
                 "-Dgtk_doc=false",
-                "-Dintrospection=false"
+                "-Dintrospection=false",
+                "-Dgcrypt=false"
             ],
             "sources": [
                 {


### PR DESCRIPTION
libsecret > 0.20 has a feature where it will try to store the secret in a local keystore inside the flatpak when it detects it's running inside a flatpak.  However, for some reason this implementation is completely borked since the beginning.  As a result any action to store or retrieve a password will hang indefinitely (except for the very first attempt sometimes).

As a workaround, it's possible to disable the libgcrypt dependency during compilation of libsecret.  Since this dependency is needed to generate the local keystore, this will effectively disable the feature.  Instead libsecret will try to retrieve/save the password from the main user keyring through the DBUS API, like it did up to version 0.19.