### PR TITLE
Run Kasts with QML_DISABLE_DISK_CACHE=1

### DIFF
--- a/org.kde.kasts.json
+++ b/org.kde.kasts.json
@@ -143,6 +143,10 @@
         {
             "name": "kasts",
             "buildsystem": "cmake-ninja",
+            "post-install": [
+                "mv /app/bin/{kasts,kasts-bin}",
+                "install run_kasts.sh /app/bin/kasts"
+            ],
             "sources": [
                 {
                     "type": "archive",
@@ -158,6 +162,10 @@
                 {
                     "type": "patch",
                     "path": "0001-force-breeze-icons.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "run_kasts.sh"
                 }
             ]
         }

--- a/run_kasts.sh
+++ b/run_kasts.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+export QML_DISABLE_DISK_CACHE=1
+exec kasts-bin "$@"


### PR DESCRIPTION
This is done to avoid issues with non-valid qml cache in flatpaks.