### PR TITLE
Fix breeze icon hardcoding

### DIFF
--- a/0001-force-breeze-icons.patch
+++ b/0001-force-breeze-icons.patch
@@ -1,12 +1,11 @@
-diff --git a/src/main.cpp b/src/main.cpp
-index d0c900b..fa5db86 100644
---- a/src/main.cpp
-+++ b/src/main.cpp
-@@ -66,6 +66,7 @@ int main(int argc, char *argv[])
-     qInstallMessageHandler(myMessageHandler);
-     QLoggingCategory::setFilterRules(QStringLiteral("org.kde.*=true"));
-     QQuickStyle::setStyle(QStringLiteral("Material"));
-+    QIcon::setThemeName(QStringLiteral("breeze"));
- #else
-     QApplication app(argc, argv);
+diff -Naur a/src/main.cpp b/src/main.cpp
+--- a/src/main.cpp	2023-01-29 16:29:55.000000000 +0100
++++ b/src/main.cpp	2023-04-18 10:22:18.341720926 +0200
+@@ -82,6 +82,7 @@
      if (qEnvironmentVariableIsEmpty("QT_QUICK_CONTROLS_STYLE")) {
+         QQuickStyle::setStyle(QStringLiteral("org.kde.desktop"));
+     }
++    QIcon::setThemeName(QStringLiteral("breeze"));
+ #endif
+ 
+ #ifdef Q_OS_WINDOWS


### PR DESCRIPTION
The previous patch was incorrectly applying it to android instead of all other platforms.