### PR TITLE
Update manifest to 23.04 changes

### DIFF
--- a/org.kde.kasts.json
+++ b/org.kde.kasts.json
@@ -13,7 +13,8 @@
         "--device=dri",
         "--socket=pulseaudio",
         "--own-name=org.mpris.MediaPlayer2.kasts",
-        "--talk-name=org.freedesktop.secrets"
+        "--talk-name=org.freedesktop.secrets",
+        "--talk-name=org.kde.StatusNotifierWatcher"
     ],
     "cleanup": [
         "/include",
@@ -167,6 +168,9 @@
                     "type": "file",
                     "path": "run_kasts.sh"
                 }
+            ],
+            "config-opts": [
+                "-DKASTS_FLATPAK=ON"
             ]
         }
     ]


### PR DESCRIPTION
This adds StatusNotifierWatcher support and switch to use qtquick1 dialogs (to work around portal problems with qtquick2 dialogs)