### PR TITLE
Enable -Dcrypto=disabled on libsecret

### DIFF
--- a/org.kde.kasts.json
+++ b/org.kde.kasts.json
@@ -83,7 +83,8 @@
                 "-Dmanpage=false",
                 "-Dvapi=false",
                 "-Dgtk_doc=false",
-                "-Dintrospection=false"
+                "-Dintrospection=false",
+                "-Dcrypto=disabled"
             ],
             "sources": [
                 {


### PR DESCRIPTION
This fixes problems with libsecret hanging instead of using the dbus protocol to save and retrieve passwords.