### PR TITLE
Revert taglib 2.0 update

### DIFF
--- a/org.kde.kasts.json
+++ b/org.kde.kasts.json
@@ -57,29 +57,13 @@
             ]
         },
         {
-            "name": "utfcpp",
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/nemtrif/utfcpp/archive/refs/tags/v4.0.5.tar.gz",
-                    "sha256": "ffc668a310e77607d393f3c18b32715f223da1eac4c4d6e0579a11df8e6b59cf",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 20545,
-                        "url-template": "https://github.com/nemtrif/utfcpp/archive/refs/tags/v$version.tar.gz"
-                    }
-                }
-            ]
-        },
-        {
             "name": "taglib",
             "buildsystem": "cmake-ninja",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://taglib.github.io/releases/taglib-2.0.tar.gz",
-                    "sha256": "e36ea877a6370810b97d84cf8f72b1e4ed205149ab3ac8232d44c850f38a2859",
+                    "url": "https://taglib.github.io/releases/taglib-1.13.1.tar.gz",
+                    "sha256": "c8da2b10f1bfec2cd7dbfcd33f4a2338db0765d851a50583d410bacf055cfd0b",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 1982,


### PR DESCRIPTION
This segfaults because it's ABI incompatible with the older version of taglib that is used by VLC internally.