### PR TITLE
Get rid of explicit taglib dependency

### DIFF
--- a/org.kde.kasts.json
+++ b/org.kde.kasts.json
@@ -57,26 +57,6 @@
             ]
         },
         {
-            "name": "taglib",
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://taglib.github.io/releases/taglib-1.13.1.tar.gz",
-                    "sha256": "c8da2b10f1bfec2cd7dbfcd33f4a2338db0765d851a50583d410bacf055cfd0b",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 1982,
-                        "stable-only": true,
-                        "url-template": "https://taglib.github.io/releases/taglib-$version.tar.gz"
-                    }
-                }
-            ],
-            "config-opts": [
-                "-DBUILD_SHARED_LIBS=ON"
-            ]
-        },
-        {
             "name": "libsecret",
             "buildsystem": "meson",
             "config-opts": [


### PR DESCRIPTION
It's already part of org.kde.Platform.  Moreover, if another version is defined in the manifest, it might clash with the built-in one and cause segfaults.